### PR TITLE
Add text flow utilities for string stream processing

### DIFF
--- a/api/xemantic-kotlin-core.api
+++ b/api/xemantic-kotlin-core.api
@@ -15,11 +15,16 @@ public final class com/xemantic/kotlin/core/text/TextBuilderKt {
 	public static final fun buildText (Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 }
 
+public final class com/xemantic/kotlin/core/text/TextFlowsKt {
+	public static final fun joinToString (Lkotlinx/coroutines/flow/Flow;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun lineFlow (Ljava/lang/CharSequence;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class com/xemantic/kotlin/core/text/TextScope {
 	public fun <init> (Ljava/lang/StringBuilder;)V
 	public final fun getBuilder ()Ljava/lang/StringBuilder;
 	public final fun trimLastNewLine ()V
 	public final fun unaryPlus (C)V
-	public final fun unaryPlus (Ljava/lang/String;)V
+	public final fun unaryPlus (Ljava/lang/CharSequence;)V
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,6 @@ kotlin {
         extraWarnings = true
         progressiveMode = true
         optIn.addAll(
-            "kotlin.time.ExperimentalTime",
             "kotlin.contracts.ExperimentalContracts"
         )
     }
@@ -117,6 +116,12 @@ kotlin {
     swiftExport {}
 
     sourceSets {
+
+        commonMain {
+            dependencies {
+                api(libs.kotlinx.coroutines.core)
+            }
+        }
 
         commonTest {
             dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,4 @@ kotlin.incremental.wasm=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+UseParallelGC

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ xemanticConventionsPlugin = "0.6.8"
 [libraries]
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 xemantic-kotlin-test = { module = "com.xemantic.kotlin:xemantic-kotlin-test", version.ref = "xemanticKotlinTest" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/commonMain/kotlin/text/TextBuilder.kt
+++ b/src/commonMain/kotlin/text/TextBuilder.kt
@@ -20,9 +20,6 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
-/**
- * This should be moved to `xemantic-core`.
- */
 @OptIn(ExperimentalContracts::class)
 public inline fun buildText(
     block: TextScope.() -> Unit
@@ -41,7 +38,7 @@ public class TextScope(
     internal val builder: StringBuilder
 ) {
 
-    public inline operator fun String.unaryPlus() {
+    public inline operator fun CharSequence.unaryPlus() {
         builder.append(this)
     }
 

--- a/src/commonMain/kotlin/text/TextFlows.kt
+++ b/src/commonMain/kotlin/text/TextFlows.kt
@@ -14,4 +14,17 @@
  * limitations under the License.
  */
 
-package com.xemantic.kotlin.core
+package com.xemantic.kotlin.core.text
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+
+public suspend fun Flow<CharSequence>.joinToString(): String = buildString {
+    collect {
+        append(it)
+    }
+}
+
+public fun CharSequence.lineFlow(): Flow<String> = lineSequence().map {
+    "$it\n"
+}.asFlow()

--- a/src/commonTest/kotlin/text/JoinToStringTest.kt
+++ b/src/commonTest/kotlin/text/JoinToStringTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.kotlin.core.text
+
+import com.xemantic.kotlin.test.sameAs
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class JoinToStringTest {
+
+    @Test
+    fun `should join flow of strings into single string`() = runTest {
+        // given
+        val flow = flowOf("Hello", " ", "World", "!")
+
+        // when
+        val result = flow.joinToString()
+
+        // then
+        result sameAs "Hello World!"
+    }
+
+    @Test
+    fun `should return empty string for empty flow`() = runTest {
+        // given
+        val flow = flowOf<String>()
+
+        // when
+        val result = flow.joinToString()
+
+        // then
+        result sameAs ""
+    }
+
+    @Test
+    fun `should handle single element flow`() = runTest {
+        // given
+        val flow = flowOf("single")
+
+        // when
+        val result = flow.joinToString()
+
+        // then
+        result sameAs "single"
+    }
+
+}

--- a/src/commonTest/kotlin/text/LineFlowTest.kt
+++ b/src/commonTest/kotlin/text/LineFlowTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Kazimierz Pogoda / Xemantic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.xemantic.kotlin.core.text
+
+import com.xemantic.kotlin.test.assert
+import com.xemantic.kotlin.test.sameAs
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class LineFlowTest {
+
+    @Test
+    fun `should flow single line with trailing newline`() = runTest {
+        // given
+        val text = "hello"
+
+        // when
+        val lines = text.lineFlow().toList()
+
+        // then
+        assert(lines.size == 1)
+        lines[0] sameAs "hello\n"
+    }
+
+    @Test
+    fun `should flow multiple lines each with trailing newline`() = runTest {
+        // given
+        val text = "line1\nline2\nline3"
+
+        // when
+        val lines = text.lineFlow().toList()
+
+        // then
+        assert(lines.size == 3)
+        lines[0] sameAs "line1\n"
+        lines[1] sameAs "line2\n"
+        lines[2] sameAs "line3\n"
+    }
+
+    @Test
+    fun `should preserve empty lines`() = runTest {
+        // given
+        val text = "line1\n\nline3"
+
+        // when
+        val lines = text.lineFlow().toList()
+
+        // then
+        assert(lines.size == 3)
+        lines[0] sameAs "line1\n"
+        lines[1] sameAs "\n"
+        lines[2] sameAs "line3\n"
+    }
+
+    @Test
+    fun `should flow empty string as single empty line with newline`() = runTest {
+        // given
+        val text = ""
+
+        // when
+        val lines = text.lineFlow().toList()
+
+        // then
+        assert(lines.size == 1)
+        lines[0] sameAs "\n"
+    }
+
+    @Test
+    fun `should reconstruct original text plus trailing newline when joined`() = runTest {
+        // given
+        val text = "first\nsecond\nthird"
+
+        // when
+        val reconstructed = text.lineFlow().joinToString()
+
+        // then
+        reconstructed sameAs "first\nsecond\nthird\n"
+    }
+
+}


### PR DESCRIPTION
## Summary

- Add `Flow<CharSequence>.joinToString()` extension for collecting flow elements into a string
- Add `CharSequence.lineFlow()` extension for converting text to a flow of lines with preserved newlines
- Update `TextScope.unaryPlus()` to accept `CharSequence` instead of `String` for broader compatibility
- Add comprehensive tests for new flow utilities

## Test plan

- [x] Unit tests added for `joinToString()` flow extension
- [x] Unit tests added for `lineFlow()` extension
- [ ] Verify build succeeds: `./gradlew build`
- [ ] Verify tests pass: `./gradlew test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)