### PR TITLE
refactor: generalize unaryPlus context extensions to Appendable

### DIFF
--- a/api/xemantic-kotlin-core.api
+++ b/api/xemantic-kotlin-core.api
@@ -25,8 +25,8 @@ public final class com/xemantic/kotlin/core/system/Environment_jvmKt {
 
 public final class com/xemantic/kotlin/core/text/StringBuilderExtensionsKt {
 	public static final fun trimLastNewLine (Ljava/lang/StringBuilder;)V
-	public static final fun unaryPlus (Ljava/lang/StringBuilder;C)V
-	public static final fun unaryPlus (Ljava/lang/StringBuilder;Ljava/lang/CharSequence;)V
+	public static final fun unaryPlus (Ljava/lang/Appendable;C)V
+	public static final fun unaryPlus (Ljava/lang/Appendable;Ljava/lang/CharSequence;)V
 }
 
 public final class com/xemantic/kotlin/core/text/TextFlowsKt {

--- a/src/commonMain/kotlin/text/StringBuilderExtensions.kt
+++ b/src/commonMain/kotlin/text/StringBuilderExtensions.kt
@@ -17,15 +17,15 @@
 package com.xemantic.kotlin.core.text
 
 @Suppress("NOTHING_TO_INLINE")
-context(builder: StringBuilder)
+context(appendable: Appendable)
 public inline operator fun CharSequence.unaryPlus() {
-    builder.append(this)
+    appendable.append(this)
 }
 
 @Suppress("NOTHING_TO_INLINE")
-context(builder: StringBuilder)
+context(appendable: Appendable)
 public inline operator fun Char.unaryPlus() {
-    builder.append(this)
+    appendable.append(this)
 }
 
 context(builder: StringBuilder)

--- a/src/wasmJsMain/kotlin/system/Environment.wasmJs.kt
+++ b/src/wasmJsMain/kotlin/system/Environment.wasmJs.kt
@@ -23,5 +23,6 @@ package com.xemantic.kotlin.core.system
 // Kotlin index access on a dynamic `process.env`.
 public actual val env: Environment = Environment { name -> getEnv(name) }
 
+@OptIn(ExperimentalWasmJsInterop::class)
 private fun getEnv(name: String): String? =
     js("(typeof process !== 'undefined' && process.env && process.env[name] != null) ? process.env[name] : null")


### PR DESCRIPTION
## Summary

- Broaden the receiver of the `unaryPlus` context extensions from `StringBuilder` to `Appendable`, so they work with any appendable target.
- Opt in to `ExperimentalWasmJsInterop` for the wasmJs `getEnv` helper.
- Regenerate the public API dump to reflect the new `Appendable` receivers.

## Test plan

- [ ] CI build passes across all targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)